### PR TITLE
Use time.h for windows

### DIFF
--- a/ofe.cc
+++ b/ofe.cc
@@ -2,7 +2,11 @@
 #include <v8.h>
 #include <v8-profiler.h>
 #include <stdlib.h>
-#include <sys/time.h>
+#if defined(_WIN32)
+	#include <time.h>
+#else 
+	#include <sys/time.h>
+#endif
 
 using namespace v8;
 


### PR DESCRIPTION
When trying to compile this module on windows, the compilation fails.

Fix taken from: https://github.com/STRML/node-toobusy/commit/696ebefce8f120d3c815f43f99847ab8c3daf205
